### PR TITLE
Seeds demo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       POSTGRES_PASSWORD: postgrespassword
 
   hasura:
+    # Will auto-apply new migrations and metadata,
+    # but not seeds!
     image: hasura/graphql-engine:v2.13.0.cli-migrations-v3
     ports:
     - "8080:8080"

--- a/schema/seeds/postgres/1665754607021_animal_seed.sql
+++ b/schema/seeds/postgres/1665754607021_animal_seed.sql
@@ -1,0 +1,1 @@
+insert into animal (species) values ('Felis catus');


### PR DESCRIPTION
## Use Case
> It's often useful to add some initial Seed data into your database as part of the initialization process, with Hasura Seeds you can do that. This is particularly useful for adding a testing user or to pre-populate values if you have set a table in Hasura as an enum table to expose it as GraphQL enums in the GraphQL API.

## Create a Hasura Seed file
```shell
hasura --project schema seed create animal_seed
```

## Apply a Hasura Seed file
```shell
hasura --project schema seed apply
```

## Note about auto-applies
[Seeds don't get auto-applied](https://github.com/hasura/graphql-engine/issues/7914) because they're typically written as inserts (not [upserts](https://stackoverflow.com/a/31742830)) and lack idempotence. If the [auto-migration image](https://hasura.io/docs/latest/migrations-metadata-seeds/auto-apply-migrations/) were to auto-apply seeds, a lot of people might be caught off guard. For that reason, it's probably better to write data for well-known enums in a Migration file, not a Seed file.